### PR TITLE
#4 ファシリテーターとして、フィボナッチ数列のカードを参加者に配りたい、なぜならプランニングポーカーで最も一般的に使用されるカードだからだ

### DIFF
--- a/components/card.tsx
+++ b/components/card.tsx
@@ -1,13 +1,13 @@
 import { NextPage } from "next";
 
 interface Props {
-  estimate: number
+  val: number
 }
 
-const Card: NextPage<Props> = ({ estimate }) => {
+const Card: NextPage<Props> = ({ val }) => {
   return (
-    <div className="box is-flex is-justify-content-center is-align-items-center is-size-3 has-text-weight-bold m-2" style={{ width: '100px', aspectRatio: '1 / 1.4' }}>
-      { estimate || '?' }
+    <div className="box is-flex is-justify-content-center is-align-items-center is-size-3 has-text-weight-bold m-2" style={{ width: '100px', minWidth: '100px', aspectRatio: '1 / 1.4', border: 'solid 1px lightgrey' }}>
+      { val || '?' }
     </div>
   )
 }

--- a/components/roomInfo.tsx
+++ b/components/roomInfo.tsx
@@ -22,8 +22,8 @@ const RoomInfo: NextPage<Props> = ({ className, roomId }) => {
   return (
     <p className={className}>
       <span>Room ID: </span>
-      <span>{ roomId }</span>
       <a onClick={copyUrl}>
+        <span>{ roomId }</span>
         <FontAwesomeIcon icon={faArrowUpFromBracket} className="ml-2" />
       </a>
     </p>

--- a/components/table.tsx
+++ b/components/table.tsx
@@ -9,16 +9,16 @@ interface Props {
   memberEstimates: MemberEstimates
 }
 
-const Field: NextPage<Props> = ({memberEstimates}) => {
+const Table: NextPage<Props> = ({memberEstimates}) => {
   return (
     <div className="box has-background-success is-flex is-flex-wrap-wrap is-justify-content-center">
       {
         Object.keys(memberEstimates).map(memberId =>
-          <Card key={memberId} estimate={memberEstimates[memberId]} />
+          <Card key={memberId} val={memberEstimates[memberId]} />
         )
       }
     </div>
   )
 }
 
-export default Field
+export default Table

--- a/components/tefuda.tsx
+++ b/components/tefuda.tsx
@@ -1,0 +1,16 @@
+import { NextPage } from "next";
+import Card from './card';
+
+const Tefuda: NextPage = () => {
+  return (
+    <div className="is-flex" style={{ overflowX: 'scroll' }}>
+      {
+        [1, 2, 3, 5, 8, 13, 21].map(val =>
+          <Card key={val} val={val} />
+        )
+      }
+    </div>
+  )
+}
+
+export default Tefuda

--- a/pages/rooms/[roomId].tsx
+++ b/pages/rooms/[roomId].tsx
@@ -4,7 +4,8 @@ import { useRouter } from 'next/router';
 import { io, Socket } from 'socket.io-client'
 import { ClientToServerEvents, ServerToClientEvents } from '../../interfaces/socket';
 import RoomInfo from '../../components/roomInfo'
-import Field from '../../components/field'
+import Table from '../../components/table'
+import Tefuda from '../../components/tefuda'
 
 let socket: Socket<ServerToClientEvents, ClientToServerEvents>
 
@@ -51,7 +52,10 @@ const Page: NextPage = () => {
     <div className='has-text-centered'>
       <section className='section'>
         <RoomInfo className="mb-5" roomId={roomId} />
-        <Field memberEstimates={memberEstimates} />
+        <Table memberEstimates={memberEstimates} />
+      </section>
+      <section className="section">
+        <Tefuda />
       </section>
     </div>
   )


### PR DESCRIPTION
- ポーカールームページで、手札として、フィボナッチ数列（1, 2, 3, 5, 8, 13, 21）のカードが表示されていること