### PR TITLE
#8 ファシリテーターとして、場に出たカードを参加者の手札に戻したい、なぜなら場がキレイな状態で仕切り直したほうがファシリテーションしやすいからだ

### DIFF
--- a/components/table.tsx
+++ b/components/table.tsx
@@ -9,11 +9,16 @@ interface Props {
   membersCards: MembersCards
   cardsAreOpen: boolean
   openCardsOnTable: () => void
+  cleanCardsOnTable: () => void
 }
 
-const Table: NextPage<Props> = ({membersCards, cardsAreOpen, openCardsOnTable}) => {
+const Table: NextPage<Props> = ({membersCards, cardsAreOpen, openCardsOnTable, cleanCardsOnTable}) => {
   const open = (): void => {
     openCardsOnTable()
+  }
+
+  const replay = (): void => {
+    cleanCardsOnTable()
   }
 
   return (
@@ -30,9 +35,13 @@ const Table: NextPage<Props> = ({membersCards, cardsAreOpen, openCardsOnTable}) 
           )
         }
       </div>
-      { !cardsAreOpen && (
-        <button className="button is-rounded" onClick={open}>OPEN</button> 
-      )}
+      {
+        cardsAreOpen ? (
+          <button className="button is-rounded" onClick={replay}>Replay</button>
+          ) : (
+          <button className="button is-rounded" onClick={open}>Open</button> 
+        )
+      }
     </div>
   )
 }

--- a/interfaces/socket.ts
+++ b/interfaces/socket.ts
@@ -5,10 +5,12 @@ interface membersCards {
 export interface ServerToClientEvents {
   'update-members-cards': (membersCards: membersCards) => void
   'update-cards-state': (cardsAreOpen: boolean) => void
+  'replay': (membersCards: membersCards) => void
 }
 
 export interface ClientToServerEvents {
   'join-room': (roomId: string) => void
   'put-down-a-card': (roomId: string, number: number | string) => void
   'open-cards-on-table': (roomId: string) => void
+  'clean-cards-on-table': (roomId: string) => void
 }

--- a/pages/api/socket.ts
+++ b/pages/api/socket.ts
@@ -55,6 +55,15 @@ const SocketHandler = (req: NextApiRequest, res: NextApiResponseSocketIO) => {
       rooms[roomId] = membersCards
     }
 
+    const replayRoom = (roomId: string): void => {
+      const roomMembers: string[] = Array.from(io.of('/').adapter.rooms.get(roomId) || new Set())
+      const membersCards: membersCards = {}
+      roomMembers.map((memberId) => {
+        membersCards[memberId] = null
+      })
+      rooms[roomId] = membersCards
+    }
+
     io.on('connection', (socket) => {
       socket.on('join-room', roomId => {
         socket.join(roomId)
@@ -76,6 +85,11 @@ const SocketHandler = (req: NextApiRequest, res: NextApiResponseSocketIO) => {
             return
           }
         })
+      })
+
+      socket.on('clean-cards-on-table', roomId => {
+        replayRoom(roomId)
+        io.to(roomId).emit('replay', rooms[roomId])
       })
 
       socket.on('disconnecting', () => {

--- a/pages/rooms/[roomId].tsx
+++ b/pages/rooms/[roomId].tsx
@@ -49,6 +49,12 @@ const Page: NextPage = () => {
         setCardsAreOpen(cardsAreOpen)
       })
 
+      socket.on('replay', (membersCards) => {
+        setMembersCards(membersCards)
+        setSelectedCard(null)
+        setCardsAreOpen(false)
+      })
+
       socket.on('disconnect', () => {
         console.log('disconnect')
       })
@@ -63,11 +69,15 @@ const Page: NextPage = () => {
     socket.emit('open-cards-on-table', roomId)
   }
 
+  const cleanCardsOnTable = (): void => {
+    socket.emit('clean-cards-on-table', roomId)
+  }
+
   return (
     <div className='has-text-centered'>
       <section className='section'>
         <RoomInfo className="mb-6" roomId={roomId} />
-        <Table membersCards={membersCards} cardsAreOpen={cardsAreOpen} openCardsOnTable={openCardsOnTable} />
+        <Table membersCards={membersCards} cardsAreOpen={cardsAreOpen} openCardsOnTable={openCardsOnTable} cleanCardsOnTable={cleanCardsOnTable} />
       </section>
       <section className="section">
         <Tefuda selectedCard={selectedCard} putDownCard={putDownCard} />


### PR DESCRIPTION
- ルームページで、カードがオープンなとき、「Replay」ボタンを選択したとき、カードが手札に戻ること
- ルームページで、カードがクローズなとき、「Replay」ボタンを選択できないこと