### PR TITLE
dark mode 見ずらいので一旦 off にする

### DIFF
--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -17,13 +17,3 @@ a {
 * {
   box-sizing: border-box;
 }
-
-@media (prefers-color-scheme: dark) {
-  html {
-    color-scheme: dark;
-  }
-  body {
-    color: white;
-    background: black;
-  }
-}


### PR DESCRIPTION
@at946 

ダークモード見ずらいので一旦オフにしてみました。
ダークモードをONにするにはテキストの色をもう少し白くしないと厳しいですね。

見づらかったダークモードの表示

<img width="577" alt="スクリーンショット 2022-10-11 13 10 09" src="https://user-images.githubusercontent.com/6353363/194995217-aba61db5-ffe6-4f0c-b670-d08568bad2cd.png">
