### PR TITLE
npx playwright で install する chromium のバージョンを固定するようにする

### DIFF
--- a/playwright/Dockerfile
+++ b/playwright/Dockerfile
@@ -22,5 +22,8 @@ RUN apt update \
         libxkbcommon0 \
         libasound2 \
         libwayland-client0
-RUN npx playwright install
-RUN yarn install
+
+COPY ./package.json .
+COPY ./yarn.lock .
+RUN yarn install \
+    && ./node_modules/.bin/playwright install


### PR DESCRIPTION
## 概要

```sh
$ docker compose run playwright yarn test
```

上記でテストを実行すると、chromium の違うバージョンが見つからなくてテストが動かなかったので対応する。