### PR TITLE
npx で実行する playwright の version を固定する

### DIFF
--- a/playwright/Dockerfile
+++ b/playwright/Dockerfile
@@ -22,5 +22,7 @@ RUN apt update \
         libxkbcommon0 \
         libasound2 \
         libwayland-client0
-RUN npx playwright install
+# ※ 注意 ※
+# ここを playwright/package.json のバージョンと揃えないとテストが動かない
+RUN npx playwright@1.29.2 install
 RUN yarn install


### PR DESCRIPTION
## 概要

playwright/package.json の playwright と playwright/Dockerfile で使っている playwright のバージョンがずれており、インストールされる chromium のバージョンが異なり、テストが動かなかったのでバージョンを揃える