### PR TITLE
Nominate Button

### DIFF
--- a/app/rooms/[roomId]/RoomPage.tsx
+++ b/app/rooms/[roomId]/RoomPage.tsx
@@ -46,6 +46,7 @@ const RoomPage: NextPage<Props> = ({ roomId }) => {
       socket.on('update-members', onUpdateMembers);
       socket.on('update-deck-type', onUpdateDeckType);
       socket.on('update-cards-are-open', onUpdateCardsAreOpen);
+      socket.on('nominate', onNominate);
       socket.on('disconnect', () => setIsConnected(false));
 
       socket.emit('join-room', roomId);
@@ -76,6 +77,10 @@ const RoomPage: NextPage<Props> = ({ roomId }) => {
     dispatch(setCardsAreOpen(cardsAreOpen));
   };
 
+  const onNominate = () => {
+    alert('You have been nominated!!🎉');
+  };
+
   const changeDeckType = (newDeckType: DeckType): void => {
     socket.emit('change-deck-type', roomId, newDeckType);
   };
@@ -97,6 +102,10 @@ const RoomPage: NextPage<Props> = ({ roomId }) => {
     socket.emit('put-down-a-card', roomId, card);
   };
 
+  const nominate = (memberId: string): void => {
+    socket.emit('nominate', memberId);
+  };
+
   return (
     <>
       <div className='has-text-centered'>
@@ -105,7 +114,7 @@ const RoomPage: NextPage<Props> = ({ roomId }) => {
             <RoomInfo roomId={roomId} />
             {isConnected && (
               <div className='mt-4'>
-                <Table openCards={openCards} replay={replay} />
+                <Table openCards={openCards} replay={replay} nominate={nominate} />
               </div>
             )}
           </div>

--- a/app/rooms/[roomId]/components/memberTypeToggle.tsx
+++ b/app/rooms/[roomId]/components/memberTypeToggle.tsx
@@ -16,7 +16,7 @@ const MemberTypeToggle: NextPage<Props> = ({ changeMemberType }) => {
   };
 
   return (
-    <div className='tabs is-toggle is-centered'>
+    <div className='tabs is-centered is-boxed'>
       <ul>
         <li
           className={type === 'player' ? 'is-active' : ''}

--- a/app/rooms/[roomId]/components/table/nominateButton.tsx
+++ b/app/rooms/[roomId]/components/table/nominateButton.tsx
@@ -1,0 +1,22 @@
+import { NextPage } from 'next';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faComment } from '@fortawesome/free-solid-svg-icons';
+
+interface Props {
+  nominate: () => void;
+}
+
+const NominateButton: NextPage<Props> = ({ nominate }) => {
+  return (
+    <button
+      className='button is-small is-primary is-inverted'
+      onClick={nominate}
+      data-testid='nominateButton'
+    >
+      <FontAwesomeIcon icon={faComment} className='mr-1' />
+      <span>nominate</span>
+    </button>
+  );
+};
+
+export default NominateButton;

--- a/app/rooms/[roomId]/components/table/summaryTag.tsx
+++ b/app/rooms/[roomId]/components/table/summaryTag.tsx
@@ -10,8 +10,8 @@ const SummaryTag: NextPage<Props> = ({ name, value, testid }) => {
   return (
     <div className='control'>
       <div className='tags has-addons' data-testid={testid}>
-        <span className='tag'>{name}</span>
-        <span className='tag is-primary'>{value}</span>
+        <span className='tag is-dark'>{name}</span>
+        <span className='tag is-white'>{value}</span>
       </div>
     </div>
   );

--- a/app/rooms/[roomId]/components/table/table.tsx
+++ b/app/rooms/[roomId]/components/table/table.tsx
@@ -6,7 +6,7 @@ import TableCards from './tableCards';
 interface Props {
   openCards: () => void;
   replay: () => void;
-  nominate: () => void;
+  nominate: (memberId: string) => void;
 }
 
 const Table: NextPage<Props> = ({ openCards, replay, nominate }) => {

--- a/app/rooms/[roomId]/components/table/table.tsx
+++ b/app/rooms/[roomId]/components/table/table.tsx
@@ -11,7 +11,7 @@ interface Props {
 const Table: NextPage<Props> = ({ openCards, replay }) => {
   return (
     <div className='box has-background-success is-shadowless'>
-      <div className='mb-4'>
+      <div className='mb-5'>
         <TableCards />
       </div>
       <div className='mb-4'>

--- a/app/rooms/[roomId]/components/table/table.tsx
+++ b/app/rooms/[roomId]/components/table/table.tsx
@@ -6,13 +6,14 @@ import TableCards from './tableCards';
 interface Props {
   openCards: () => void;
   replay: () => void;
+  nominate: () => void;
 }
 
-const Table: NextPage<Props> = ({ openCards, replay }) => {
+const Table: NextPage<Props> = ({ openCards, replay, nominate }) => {
   return (
     <div className='box has-background-success is-shadowless'>
       <div className='mb-5'>
-        <TableCards />
+        <TableCards nominate={nominate} />
       </div>
       <div className='mb-4'>
         <SummaryTags />

--- a/app/rooms/[roomId]/components/table/tableButton.tsx
+++ b/app/rooms/[roomId]/components/table/tableButton.tsx
@@ -17,7 +17,7 @@ const TableButton: NextPage<Props> = ({ clickOpenButton, clickReplayButton }) =>
     <div>
       {cardsAreOpen ? (
         <button
-          className='button is-rounded is-light is-primary'
+          className='button is-rounded is-primary'
           onClick={clickReplayButton}
           data-testid='replayButton'
         >
@@ -25,7 +25,7 @@ const TableButton: NextPage<Props> = ({ clickOpenButton, clickReplayButton }) =>
         </button>
       ) : (
         <button
-          className='button is-rounded is-light is-primary'
+          className='button is-rounded is-primary'
           onClick={clickOpenButton}
           disabled={noCardPutOnTable}
           data-testid='openButton'

--- a/app/rooms/[roomId]/components/table/tableCard.tsx
+++ b/app/rooms/[roomId]/components/table/tableCard.tsx
@@ -6,23 +6,25 @@ import { useAppSelector } from '../../../../../store/hooks';
 
 interface Props {
   card: IFCard;
+  cardStatus: string;
 }
 
-const TableCard: NextPage<Props> = ({ card }) => {
+const TableCard: NextPage<Props> = ({ card, cardStatus }) => {
   let displayCard: IFCard = '';
   let additionalClassName: string = '';
   const isBlank = card === null;
   const isOpen = useAppSelector((state) => state.room.cardsAreOpen);
 
-  if (isBlank) {
-    additionalClassName = styles.blank;
-  } else {
-    if (isOpen) {
+  switch (cardStatus) {
+    case 'blank':
+      additionalClassName = styles.blank;
+      break;
+    case 'open':
       displayCard = card;
       additionalClassName = 'tableCard_open';
-    } else {
+      break;
+    default: // close
       additionalClassName = styles.close;
-    }
   }
 
   return <Card value={displayCard} additionalClassName={additionalClassName} testId='tableCard' />;

--- a/app/rooms/[roomId]/components/table/tableCardGroup.tsx
+++ b/app/rooms/[roomId]/components/table/tableCardGroup.tsx
@@ -1,0 +1,24 @@
+import { NextPage } from 'next';
+import { useAppSelector } from '@/store/hooks';
+import { Member } from '@/interfaces/member';
+import TableCard from './tableCard';
+import NominateButton from './nominateButton';
+
+interface Props {
+  player: Member;
+  nominate: () => void;
+}
+
+const TableCardGroup: NextPage<Props> = ({ player, nominate }) => {
+  const cardsAreOpen: boolean = useAppSelector((state) => state.room.cardsAreOpen);
+  const cardStatus = player.selectedCard === null ? 'blank' : cardsAreOpen ? 'open' : 'close';
+
+  return (
+    <div data-testid='tableCardGroup'>
+      <TableCard card={player.selectedCard} cardStatus={cardStatus} />
+      {cardStatus === 'open' && <NominateButton nominate={() => nominate(player.id)} />}
+    </div>
+  );
+};
+
+export default TableCardGroup;

--- a/app/rooms/[roomId]/components/table/tableCardGroup.tsx
+++ b/app/rooms/[roomId]/components/table/tableCardGroup.tsx
@@ -6,7 +6,7 @@ import NominateButton from './nominateButton';
 
 interface Props {
   player: Member;
-  nominate: () => void;
+  nominate: (memberId: string) => void;
 }
 
 const TableCardGroup: NextPage<Props> = ({ player, nominate }) => {

--- a/app/rooms/[roomId]/components/table/tableCards.tsx
+++ b/app/rooms/[roomId]/components/table/tableCards.tsx
@@ -1,16 +1,32 @@
 import { NextPage } from 'next';
 import TableCard from './tableCard';
-import { Member } from '../../../../../interfaces/member';
+import { Member } from '@/interfaces/member';
+import { Card } from '@/interfaces/card';
 import { useAppSelector } from '../../../../../store/hooks';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faQuestion } from '@fortawesome/free-solid-svg-icons';
 
 const TableCards: NextPage = () => {
   const members: Member[] = useAppSelector((state) => state.members.members);
   const players: Member[] = members.filter((v) => v.type === 'player');
+  const cardsAreOpen: boolean = useAppSelector((state) => state.room.cardsAreOpen)
+  const cardStatus = (card: Card): string => {
+    return card === null ? 'blank' : cardsAreOpen ? 'open' : 'close'
+  }
 
   return (
     <div className='is-flex is-flex-wrap-wrap is-justify-content-center'>
       {players.map((player) => (
-        <TableCard key={player.id} card={player.selectedCard} />
+        <div key={player.id} data-testid="tableCardGroup">
+          <TableCard card={player.selectedCard} cardStatus={cardStatus(player.selectedCard)} />
+
+          { cardStatus(player.selectedCard) === 'open' &&
+            <button className="button is-small is-primary is-inverted" data-testid="nominateButton">
+              <FontAwesomeIcon icon={faQuestion} className="mr-1" />
+              <span>指名</span>
+            </button>
+          }
+        </div>
       ))}
     </div>
   );

--- a/app/rooms/[roomId]/components/table/tableCards.tsx
+++ b/app/rooms/[roomId]/components/table/tableCards.tsx
@@ -4,7 +4,7 @@ import { Member } from '@/interfaces/member';
 import TableCardGroup from './tableCardGroup';
 
 interface Props {
-  nominate: () => void;
+  nominate: (memberId: string) => void;
 }
 
 const TableCards: NextPage<Props> = ({ nominate }) => {

--- a/app/rooms/[roomId]/components/table/tableCards.tsx
+++ b/app/rooms/[roomId]/components/table/tableCards.tsx
@@ -1,32 +1,20 @@
 import { NextPage } from 'next';
-import TableCard from './tableCard';
+import { useAppSelector } from '@/store/hooks';
 import { Member } from '@/interfaces/member';
-import { Card } from '@/interfaces/card';
-import { useAppSelector } from '../../../../../store/hooks';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faQuestion } from '@fortawesome/free-solid-svg-icons';
+import TableCardGroup from './tableCardGroup';
 
-const TableCards: NextPage = () => {
+interface Props {
+  nominate: () => void;
+}
+
+const TableCards: NextPage<Props> = ({ nominate }) => {
   const members: Member[] = useAppSelector((state) => state.members.members);
   const players: Member[] = members.filter((v) => v.type === 'player');
-  const cardsAreOpen: boolean = useAppSelector((state) => state.room.cardsAreOpen)
-  const cardStatus = (card: Card): string => {
-    return card === null ? 'blank' : cardsAreOpen ? 'open' : 'close'
-  }
 
   return (
     <div className='is-flex is-flex-wrap-wrap is-justify-content-center'>
       {players.map((player) => (
-        <div key={player.id} data-testid="tableCardGroup">
-          <TableCard card={player.selectedCard} cardStatus={cardStatus(player.selectedCard)} />
-
-          { cardStatus(player.selectedCard) === 'open' &&
-            <button className="button is-small is-primary is-inverted" data-testid="nominateButton">
-              <FontAwesomeIcon icon={faQuestion} className="mr-1" />
-              <span>指名</span>
-            </button>
-          }
-        </div>
+        <TableCardGroup player={player} nominate={nominate} key={player.id} />
       ))}
     </div>
   );

--- a/interfaces/socket.ts
+++ b/interfaces/socket.ts
@@ -7,6 +7,7 @@ export interface ServerToClientEvents {
   'update-members': (members: Member[]) => void;
   'update-deck-type': (deckType: DeckType) => void;
   'update-cards-are-open': (cardsAreOpen: boolean) => void;
+  nominate: () => void;
 }
 
 export interface ClientToServerEvents {
@@ -16,4 +17,5 @@ export interface ClientToServerEvents {
   'open-cards': (roomId: string) => void;
   replay: (roomId: string) => void;
   'change-member-type': (roomId: string, memberType: MemberType) => void;
+  nominate: (memberId: string) => void;
 }

--- a/pages/api/socket.ts
+++ b/pages/api/socket.ts
@@ -123,6 +123,10 @@ const SocketHandler = (req: NextApiRequest, res: NextApiResponseSocketIO) => {
         io.to(roomId).emit('update-members', room.members);
       });
 
+      socket.on('nominate', (memberId) => {
+        io.to(memberId).emit('nominate');
+      });
+
       socket.on('disconnecting', () => {
         socket.rooms.forEach((roomId) => {
           const room: Room | undefined = rooms.find((v) => v.id === roomId);

--- a/playwright/tests/rooms/nominate.spec.ts
+++ b/playwright/tests/rooms/nominate.spec.ts
@@ -3,13 +3,42 @@ import urls from '../../helpers/urls';
 import usersJoinRoom from '../../helpers/usersJoinRoom';
 
 test('ルームページで、カードをオープンしていないとき、「指名」ボタンが表示されないこと', async ({ context }) => {
-  // Given - ルームページでカードをオープンしていない
-  const [page1, page2] = await usersJoinRoom(context, urls.room(), 2)
+  // Given - ルームページでカードを選んでいる
+  const [page1, page2, page3] = await usersJoinRoom(context, urls.room(), 3)
   await page1.getByTestId('tefudaCard').nth(0).click()
+  await page2.getByTestId('tefudaCard').nth(2).click()
 
-  // When - 特になし
+  // When - カードをオープンしない
 
   // Then - 「指名」ボタンがTableCardsに表示されていない
-  await expect(page1.getByTestId('nominateButton')).not.toBeVisible()
-  await expect(page2.getByTestId('nominateButton')).not.toBeVisible()
+  await expect(page1.getByTestId('tableCardGroup').nth(0).getByTestId('nominateButton')).not.toBeVisible()
+  await expect(page1.getByTestId('tableCardGroup').nth(1).getByTestId('nominateButton')).not.toBeVisible()
+  await expect(page1.getByTestId('tableCardGroup').nth(2).getByTestId('nominateButton')).not.toBeVisible()
+  await expect(page2.getByTestId('tableCardGroup').nth(0).getByTestId('nominateButton')).not.toBeVisible()
+  await expect(page2.getByTestId('tableCardGroup').nth(1).getByTestId('nominateButton')).not.toBeVisible()
+  await expect(page2.getByTestId('tableCardGroup').nth(2).getByTestId('nominateButton')).not.toBeVisible()
+  await expect(page3.getByTestId('tableCardGroup').nth(0).getByTestId('nominateButton')).not.toBeVisible()
+  await expect(page3.getByTestId('tableCardGroup').nth(1).getByTestId('nominateButton')).not.toBeVisible()
+  await expect(page3.getByTestId('tableCardGroup').nth(2).getByTestId('nominateButton')).not.toBeVisible()
+})
+
+test('ルームページで、カードをオープンしているとき、「指名」ボタンがカードの下に表示されること', async ({ context }) => {
+  // Given - ルームページでカードを選んでいる
+  const [page1, page2, page3] = await usersJoinRoom(context, urls.room(), 3)
+  await page1.getByTestId('tefudaCard').nth(0).click()
+  await page2.getByTestId('tefudaCard').nth(2).click()
+
+  // When - カードをオープンする
+  await page1.getByTestId('openButton').click()
+
+  // Then - オープンしたカードには「指名」ボタンが表示される
+  await expect(page1.getByTestId('tableCardGroup').nth(0).getByTestId('nominateButton')).toBeVisible()
+  await expect(page1.getByTestId('tableCardGroup').nth(1).getByTestId('nominateButton')).toBeVisible()
+  await expect(page1.getByTestId('tableCardGroup').nth(2).getByTestId('nominateButton')).not.toBeVisible()
+  await expect(page2.getByTestId('tableCardGroup').nth(0).getByTestId('nominateButton')).toBeVisible()
+  await expect(page2.getByTestId('tableCardGroup').nth(1).getByTestId('nominateButton')).toBeVisible()
+  await expect(page2.getByTestId('tableCardGroup').nth(2).getByTestId('nominateButton')).not.toBeVisible()
+  await expect(page3.getByTestId('tableCardGroup').nth(0).getByTestId('nominateButton')).toBeVisible()
+  await expect(page3.getByTestId('tableCardGroup').nth(1).getByTestId('nominateButton')).toBeVisible()
+  await expect(page3.getByTestId('tableCardGroup').nth(2).getByTestId('nominateButton')).not.toBeVisible()
 })

--- a/playwright/tests/rooms/nominate.spec.ts
+++ b/playwright/tests/rooms/nominate.spec.ts
@@ -2,43 +2,111 @@ import { test, expect } from '@playwright/test';
 import urls from '../../helpers/urls';
 import usersJoinRoom from '../../helpers/usersJoinRoom';
 
-test('ルームページで、カードをオープンしていないとき、「指名」ボタンが表示されないこと', async ({ context }) => {
+test('ルームページで、カードをオープンしていないとき、「指名」ボタンが表示されないこと', async ({
+  context,
+}) => {
   // Given - ルームページでカードを選んでいる
-  const [page1, page2, page3] = await usersJoinRoom(context, urls.room(), 3)
-  await page1.getByTestId('tefudaCard').nth(0).click()
-  await page2.getByTestId('tefudaCard').nth(2).click()
+  const [page1, page2, page3] = await usersJoinRoom(context, urls.room(), 3);
+  await page1.getByTestId('tefudaCard').nth(0).click();
+  await page2.getByTestId('tefudaCard').nth(2).click();
 
   // When - カードをオープンしない
 
   // Then - 「指名」ボタンがTableCardsに表示されていない
-  await expect(page1.getByTestId('tableCardGroup').nth(0).getByTestId('nominateButton')).not.toBeVisible()
-  await expect(page1.getByTestId('tableCardGroup').nth(1).getByTestId('nominateButton')).not.toBeVisible()
-  await expect(page1.getByTestId('tableCardGroup').nth(2).getByTestId('nominateButton')).not.toBeVisible()
-  await expect(page2.getByTestId('tableCardGroup').nth(0).getByTestId('nominateButton')).not.toBeVisible()
-  await expect(page2.getByTestId('tableCardGroup').nth(1).getByTestId('nominateButton')).not.toBeVisible()
-  await expect(page2.getByTestId('tableCardGroup').nth(2).getByTestId('nominateButton')).not.toBeVisible()
-  await expect(page3.getByTestId('tableCardGroup').nth(0).getByTestId('nominateButton')).not.toBeVisible()
-  await expect(page3.getByTestId('tableCardGroup').nth(1).getByTestId('nominateButton')).not.toBeVisible()
-  await expect(page3.getByTestId('tableCardGroup').nth(2).getByTestId('nominateButton')).not.toBeVisible()
-})
+  await expect(
+    page1.getByTestId('tableCardGroup').nth(0).getByTestId('nominateButton'),
+  ).not.toBeVisible();
+  await expect(
+    page1.getByTestId('tableCardGroup').nth(1).getByTestId('nominateButton'),
+  ).not.toBeVisible();
+  await expect(
+    page1.getByTestId('tableCardGroup').nth(2).getByTestId('nominateButton'),
+  ).not.toBeVisible();
+  await expect(
+    page2.getByTestId('tableCardGroup').nth(0).getByTestId('nominateButton'),
+  ).not.toBeVisible();
+  await expect(
+    page2.getByTestId('tableCardGroup').nth(1).getByTestId('nominateButton'),
+  ).not.toBeVisible();
+  await expect(
+    page2.getByTestId('tableCardGroup').nth(2).getByTestId('nominateButton'),
+  ).not.toBeVisible();
+  await expect(
+    page3.getByTestId('tableCardGroup').nth(0).getByTestId('nominateButton'),
+  ).not.toBeVisible();
+  await expect(
+    page3.getByTestId('tableCardGroup').nth(1).getByTestId('nominateButton'),
+  ).not.toBeVisible();
+  await expect(
+    page3.getByTestId('tableCardGroup').nth(2).getByTestId('nominateButton'),
+  ).not.toBeVisible();
+});
 
-test('ルームページで、カードをオープンしているとき、「指名」ボタンがカードの下に表示されること', async ({ context }) => {
+test('ルームページで、カードをオープンしているとき、「指名」ボタンがカードの下に表示されること', async ({
+  context,
+}) => {
   // Given - ルームページでカードを選んでいる
-  const [page1, page2, page3] = await usersJoinRoom(context, urls.room(), 3)
-  await page1.getByTestId('tefudaCard').nth(0).click()
-  await page2.getByTestId('tefudaCard').nth(2).click()
+  const [page1, page2, page3] = await usersJoinRoom(context, urls.room(), 3);
+  await page1.getByTestId('tefudaCard').nth(0).click();
+  await page2.getByTestId('tefudaCard').nth(2).click();
 
   // When - カードをオープンする
-  await page1.getByTestId('openButton').click()
+  await page1.getByTestId('openButton').click();
 
   // Then - オープンしたカードには「指名」ボタンが表示される
-  await expect(page1.getByTestId('tableCardGroup').nth(0).getByTestId('nominateButton')).toBeVisible()
-  await expect(page1.getByTestId('tableCardGroup').nth(1).getByTestId('nominateButton')).toBeVisible()
-  await expect(page1.getByTestId('tableCardGroup').nth(2).getByTestId('nominateButton')).not.toBeVisible()
-  await expect(page2.getByTestId('tableCardGroup').nth(0).getByTestId('nominateButton')).toBeVisible()
-  await expect(page2.getByTestId('tableCardGroup').nth(1).getByTestId('nominateButton')).toBeVisible()
-  await expect(page2.getByTestId('tableCardGroup').nth(2).getByTestId('nominateButton')).not.toBeVisible()
-  await expect(page3.getByTestId('tableCardGroup').nth(0).getByTestId('nominateButton')).toBeVisible()
-  await expect(page3.getByTestId('tableCardGroup').nth(1).getByTestId('nominateButton')).toBeVisible()
-  await expect(page3.getByTestId('tableCardGroup').nth(2).getByTestId('nominateButton')).not.toBeVisible()
-})
+  await expect(
+    page1.getByTestId('tableCardGroup').nth(0).getByTestId('nominateButton'),
+  ).toBeVisible();
+  await expect(
+    page1.getByTestId('tableCardGroup').nth(1).getByTestId('nominateButton'),
+  ).toBeVisible();
+  await expect(
+    page1.getByTestId('tableCardGroup').nth(2).getByTestId('nominateButton'),
+  ).not.toBeVisible();
+  await expect(
+    page2.getByTestId('tableCardGroup').nth(0).getByTestId('nominateButton'),
+  ).toBeVisible();
+  await expect(
+    page2.getByTestId('tableCardGroup').nth(1).getByTestId('nominateButton'),
+  ).toBeVisible();
+  await expect(
+    page2.getByTestId('tableCardGroup').nth(2).getByTestId('nominateButton'),
+  ).not.toBeVisible();
+  await expect(
+    page3.getByTestId('tableCardGroup').nth(0).getByTestId('nominateButton'),
+  ).toBeVisible();
+  await expect(
+    page3.getByTestId('tableCardGroup').nth(1).getByTestId('nominateButton'),
+  ).toBeVisible();
+  await expect(
+    page3.getByTestId('tableCardGroup').nth(2).getByTestId('nominateButton'),
+  ).not.toBeVisible();
+});
+
+test('ルームページで、「指名」ボタンを選択したとき、そのカードを場に出したメンバーに「指名アラート」が表示されること', async ({
+  context,
+}) => {
+  // Given - ルームページで、カードをオープンする
+  // page1,2はカードを選択、page3はカード未選択
+  const [page1, page2, page3] = await usersJoinRoom(context, urls.room(), 3);
+  await page1.getByTestId('tefudaCard').nth(0).click();
+  await page2.getByTestId('tefudaCard').nth(1).click();
+  await page1.getByTestId('openButton').click();
+
+  // Then - page1にだけ指名アラートが表示される
+  // page1でdialogが出たらacceptする
+  page1.on('dialog', async (dialog) => {
+    await expect(dialog.message()).toBe('You have been nominated!!🎉');
+    dialog.accept();
+  });
+  // page2や3でdialogが出たらテスト失敗
+  page2.on('dialog', async (dialog) => await expect(true).toBeFalsy());
+  page3.on('dialog', async (dialog) => await expect(true).toBeFalsy());
+
+  // When - page1の出したカードの指名ボタンを選択
+  await page2
+    .getByTestId('tableCardGroup')
+    .filter({ hasText: '0' })
+    .getByTestId('nominateButton')
+    .click();
+});

--- a/playwright/tests/rooms/nominate.spec.ts
+++ b/playwright/tests/rooms/nominate.spec.ts
@@ -1,0 +1,15 @@
+import { test, expect } from '@playwright/test';
+import urls from '../../helpers/urls';
+import usersJoinRoom from '../../helpers/usersJoinRoom';
+
+test('ルームページで、カードをオープンしていないとき、「指名」ボタンが表示されないこと', async ({ context }) => {
+  // Given - ルームページでカードをオープンしていない
+  const [page1, page2] = await usersJoinRoom(context, urls.room(), 2)
+  await page1.getByTestId('tefudaCard').nth(0).click()
+
+  // When - 特になし
+
+  // Then - 「指名」ボタンがTableCardsに表示されていない
+  await expect(page1.getByTestId('nominateButton')).not.toBeVisible()
+  await expect(page2.getByTestId('nominateButton')).not.toBeVisible()
+})

--- a/styles/color.scss
+++ b/styles/color.scss
@@ -1,4 +1,2 @@
 $primary: #812990;
 $danger: hsl(348, 100%, 61%);
-$tabs-toggle-link-active-background-color: $primary;
-$tabs-toggle-link-active-border-color: $primary;


### PR DESCRIPTION
- ルームページで、カードをオープンしていないとき、「指名」ボタンが表示されないこと
- ルームページで、カードをオープンしているとき、「指名」ボタンがカードの下に表示されること
- ルームページで、「指名」ボタンを選択したとき、そのカードを場に出したメンバーに「指名アラート」が表示されること
- ルームページで、「指名」ボタンを選択したとき、そのカードを場に出したメンバー以外には「指名アラート」が表示されないこと
- ルームページで、「指名アラート」で「OK」を選択したとき、「指名アラート」が閉じること