### PR TITLE
集計タグを常に表示

### DIFF
--- a/app/rooms/[roomId]/components/card.tsx
+++ b/app/rooms/[roomId]/components/card.tsx
@@ -4,7 +4,7 @@ import styles from './card.module.scss';
 
 interface Props {
   value?: Card;
-  additionalClassName?: string;
+  extraClass?: string;
   role?: string;
   ariaLabel?: string;
   ariaDisabled?: boolean;
@@ -13,7 +13,7 @@ interface Props {
 
 const Card: NextPage<Props> = ({
   value,
-  additionalClassName,
+  extraClass,
   role,
   ariaLabel,
   ariaDisabled,
@@ -31,7 +31,7 @@ const Card: NextPage<Props> = ({
 
   return (
     <div
-      className={`${className} ${additionalClassName}`}
+      className={`${className} ${extraClass}`}
       role={role}
       aria-label={ariaLabel}
       aria-disabled={ariaDisabled}

--- a/app/rooms/[roomId]/components/hands/handsCard.tsx
+++ b/app/rooms/[roomId]/components/hands/handsCard.tsx
@@ -27,7 +27,7 @@ const HandsCard: NextPage<Props> = ({ card, putDownCard }) => {
     <a onClick={select}>
       <Card
         value={card}
-        additionalClassName={isSelected ? styles.selected : isDisabled ? styles.disabled : ''}
+        extraClass={isSelected ? styles.selected : isDisabled ? styles.disabled : ''}
         role='option'
         ariaLabel='手札カード'
         ariaSelected={isSelected}

--- a/app/rooms/[roomId]/components/table/summaryTag.tsx
+++ b/app/rooms/[roomId]/components/table/summaryTag.tsx
@@ -2,7 +2,7 @@ import { NextPage } from 'next';
 
 interface Props {
   name: string;
-  value: number;
+  value: number | string;
   ariaLabel?: string;
 }
 

--- a/app/rooms/[roomId]/components/table/summaryTags.tsx
+++ b/app/rooms/[roomId]/components/table/summaryTags.tsx
@@ -14,13 +14,13 @@ const SummaryTags: NextPage = ({ className }) => {
   const cards: Card[] = players.map((v) => v.selectedCard);
   const numberCards: number[] = cards.filter<number>((v): v is number => typeof v === 'number');
   const cardsAreOpen = useAppSelector((state) => state.room.cardsAreOpen);
-  const isAvailable = cardsAreOpen && numberCards.length > 0;
+  const useCalculatedResult = cardsAreOpen && numberCards.length > 0;
 
-  const minValue: number | string = isAvailable ? Math.min(...numberCards) : '?';
-  const maxValue: number | string = isAvailable ? Math.max(...numberCards) : '?';
-  const avgValue: number | string = isAvailable ?
-    Math.round((numberCards.reduce((a, b) => a + b, 0) / numberCards.length) * 10) / 10 : '?';
-
+  const minValue: number | string = useCalculatedResult ? Math.min(...numberCards) : '?';
+  const maxValue: number | string = useCalculatedResult ? Math.max(...numberCards) : '?';
+  const avgValue: number | string = useCalculatedResult
+    ? Math.round((numberCards.reduce((a, b) => a + b, 0) / numberCards.length) * 10) / 10
+    : '?';
 
   return (
     <div className={className}>

--- a/app/rooms/[roomId]/components/table/summaryTags.tsx
+++ b/app/rooms/[roomId]/components/table/summaryTags.tsx
@@ -4,28 +4,31 @@ import { Member } from '@/interfaces/member';
 import { useAppSelector } from '@/store/hooks';
 import SummaryTag from './summaryTag';
 
-const SummaryTags: NextPage = () => {
+interface Props {
+  className?: string;
+}
+
+const SummaryTags: NextPage = ({ className }) => {
   const members: Member[] = useAppSelector((state) => state.members.members);
   const players: Member[] = members.filter((v) => v.type === 'player');
   const cards: Card[] = players.map((v) => v.selectedCard);
   const numberCards: number[] = cards.filter<number>((v): v is number => typeof v === 'number');
-  const minCard: number = Math.min(...numberCards);
-  const maxCard: number = Math.max(...numberCards);
-  const avgValue: number =
-    Math.round((numberCards.reduce((a, b) => a + b, 0) / numberCards.length) * 10) / 10;
-
   const cardsAreOpen = useAppSelector((state) => state.room.cardsAreOpen);
-  const isVisible = cardsAreOpen && numberCards.length > 0;
+  const isAvailable = cardsAreOpen && numberCards.length > 0;
+
+  const minValue: number | string = isAvailable ? Math.min(...numberCards) : '?';
+  const maxValue: number | string = isAvailable ? Math.max(...numberCards) : '?';
+  const avgValue: number | string = isAvailable ?
+    Math.round((numberCards.reduce((a, b) => a + b, 0) / numberCards.length) * 10) / 10 : '?';
+
 
   return (
-    <div>
-      {isVisible && (
-        <div className='field is-grouped is-grouped-multiline is-grouped-centered'>
-          <SummaryTag name='Min' value={minCard} ariaLabel='最小値' />
-          <SummaryTag name='Avg' value={avgValue} ariaLabel='平均値' />
-          <SummaryTag name='Max' value={maxCard} ariaLabel='最大値' />
-        </div>
-      )}
+    <div className={className}>
+      <div className='field is-grouped is-grouped-multiline is-grouped-centered'>
+        <SummaryTag name='最小' value={minValue} ariaLabel='最小値' />
+        <SummaryTag name='平均' value={avgValue} ariaLabel='平均値' />
+        <SummaryTag name='最大' value={maxValue} ariaLabel='最大値' />
+      </div>
     </div>
   );
 };

--- a/app/rooms/[roomId]/components/table/summaryTags.tsx
+++ b/app/rooms/[roomId]/components/table/summaryTags.tsx
@@ -5,10 +5,10 @@ import { useAppSelector } from '@/store/hooks';
 import SummaryTag from './summaryTag';
 
 interface Props {
-  className?: string;
+  extraClass?: string;
 }
 
-const SummaryTags: NextPage = ({ className }) => {
+const SummaryTags: NextPage = ({ extraClass }) => {
   const members: Member[] = useAppSelector((state) => state.members.members);
   const players: Member[] = members.filter((v) => v.type === 'player');
   const cards: Card[] = players.map((v) => v.selectedCard);
@@ -23,7 +23,7 @@ const SummaryTags: NextPage = ({ className }) => {
     : '?';
 
   return (
-    <div className={className}>
+    <div className={extraClass}>
       <div className='field is-grouped is-grouped-multiline is-grouped-centered'>
         <SummaryTag name='最小' value={minValue} ariaLabel='最小値' />
         <SummaryTag name='平均' value={avgValue} ariaLabel='平均値' />

--- a/app/rooms/[roomId]/components/table/summaryTags.tsx
+++ b/app/rooms/[roomId]/components/table/summaryTags.tsx
@@ -8,7 +8,7 @@ interface Props {
   extraClass?: string;
 }
 
-const SummaryTags: NextPage = ({ extraClass }) => {
+const SummaryTags: NextPage<Props> = ({ extraClass }) => {
   const members: Member[] = useAppSelector((state) => state.members.members);
   const players: Member[] = members.filter((v) => v.type === 'player');
   const cards: Card[] = players.map((v) => v.selectedCard);

--- a/app/rooms/[roomId]/components/table/table.tsx
+++ b/app/rooms/[roomId]/components/table/table.tsx
@@ -16,9 +16,7 @@ const Table: NextPage<Props> = ({ openCards, replay, nominate }) => {
   return (
     <div className='box has-background-success is-shadowless'>
       <TableCardGroups className='mb-5' nominate={nominate} />
-      { deckType !== 'tShirtSize' &&
-        <SummaryTags className="mb-4" />
-      }
+      {deckType !== 'tShirtSize' && <SummaryTags className='mb-4' />}
       <TableButton clickOpenButton={openCards} clickReplayButton={replay} />
     </div>
   );

--- a/app/rooms/[roomId]/components/table/table.tsx
+++ b/app/rooms/[roomId]/components/table/table.tsx
@@ -2,6 +2,7 @@ import { NextPage } from 'next';
 import TableButton from './tableButton';
 import SummaryTags from './summaryTags';
 import TableCardGroups from './tableCardGroups';
+import { useAppSelector } from '@/store/hooks';
 
 interface Props {
   openCards: () => void;
@@ -10,14 +11,14 @@ interface Props {
 }
 
 const Table: NextPage<Props> = ({ openCards, replay, nominate }) => {
+  const deckType: string = useAppSelector((state) => state.room.deckType);
+
   return (
     <div className='box has-background-success is-shadowless'>
-      <div className='mb-5'>
-        <TableCardGroups nominate={nominate} />
-      </div>
-      <div className='mb-4'>
-        <SummaryTags />
-      </div>
+      <TableCardGroups className='mb-5' nominate={nominate} />
+      { deckType !== 'tShirtSize' &&
+        <SummaryTags className="mb-4" />
+      }
       <TableButton clickOpenButton={openCards} clickReplayButton={replay} />
     </div>
   );

--- a/app/rooms/[roomId]/components/table/table.tsx
+++ b/app/rooms/[roomId]/components/table/table.tsx
@@ -15,8 +15,8 @@ const Table: NextPage<Props> = ({ openCards, replay, nominate }) => {
 
   return (
     <div className='box has-background-success is-shadowless'>
-      <TableCardGroups className='mb-5' nominate={nominate} />
-      {deckType !== 'tShirtSize' && <SummaryTags className='mb-4' />}
+      <TableCardGroups extraClass='mb-4' nominate={nominate} />
+      {deckType !== 'tShirtSize' && <SummaryTags extraClass='mb-4' />}
       <TableButton clickOpenButton={openCards} clickReplayButton={replay} />
     </div>
   );

--- a/app/rooms/[roomId]/components/table/tableCard.tsx
+++ b/app/rooms/[roomId]/components/table/tableCard.tsx
@@ -14,10 +14,10 @@ const TableCard: NextPage<Props> = ({ value, status }) => {
   if (status === 'faceUp') {
     return <Card value={value} ariaLabel={`めくられたテーブルカード ${value}`} />;
   } else if (status === 'faceDown') {
-    return <Card additionalClassName={styles['face-down']} ariaLabel='伏せられたテーブルカード' />;
+    return <Card extraClass={styles['face-down']} ariaLabel='伏せられたテーブルカード' />;
   } else {
     // blank
-    return <Card additionalClassName={styles.blank} ariaLabel='未選択のテーブルカード' />;
+    return <Card extraClass={styles.blank} ariaLabel='未選択のテーブルカード' />;
   }
 };
 

--- a/app/rooms/[roomId]/components/table/tableCardGroups.tsx
+++ b/app/rooms/[roomId]/components/table/tableCardGroups.tsx
@@ -4,15 +4,16 @@ import { Member } from '@/interfaces/member';
 import TableCardGroup from './tableCardGroup';
 
 interface Props {
+  className?: string;
   nominate: (memberId: string) => void;
 }
 
-const TableCardGroups: NextPage<Props> = ({ nominate }) => {
+const TableCardGroups: NextPage<Props> = ({ className, nominate }) => {
   const members: Member[] = useAppSelector((state) => state.members.members);
   const players: Member[] = members.filter((v) => v.type === 'player');
 
   return (
-    <div className='is-flex is-flex-wrap-wrap is-justify-content-center'>
+    <div className={`is-flex is-flex-wrap-wrap is-justify-content-center ${className || ''}`}>
       {players.map((player) => (
         <TableCardGroup player={player} nominate={nominate} key={player.id} />
       ))}

--- a/app/rooms/[roomId]/components/table/tableCardGroups.tsx
+++ b/app/rooms/[roomId]/components/table/tableCardGroups.tsx
@@ -4,16 +4,16 @@ import { Member } from '@/interfaces/member';
 import TableCardGroup from './tableCardGroup';
 
 interface Props {
-  className?: string;
+  extraClass?: string;
   nominate: (memberId: string) => void;
 }
 
-const TableCardGroups: NextPage<Props> = ({ className, nominate }) => {
+const TableCardGroups: NextPage<Props> = ({ extraClass, nominate }) => {
   const members: Member[] = useAppSelector((state) => state.members.members);
   const players: Member[] = members.filter((v) => v.type === 'player');
 
   return (
-    <div className={`is-flex is-flex-wrap-wrap is-justify-content-center ${className || ''}`}>
+    <div className={`is-flex is-flex-wrap-wrap is-justify-content-center ${extraClass || ''}`}>
       {players.map((player) => (
         <TableCardGroup player={player} nominate={nominate} key={player.id} />
       ))}

--- a/playwright/tests/rooms/summary.spec.ts
+++ b/playwright/tests/rooms/summary.spec.ts
@@ -2,7 +2,9 @@ import { test, expect } from '@playwright/test';
 import RoomPage from '../../models/room-page';
 import createRoomId from '../../helpers/createRoomId';
 
-test('ルームページで、フィボナッチ数列デッキを選択しており、カードがオープンされてないとき、サマリーはすべて「？」であること', async ({ context }) => {
+test('ルームページで、フィボナッチ数列デッキを選択しており、カードがオープンされてないとき、サマリーはすべて「？」であること', async ({
+  context,
+}) => {
   // Given
   const roomId: string = createRoomId();
   const roomPage1: RoomPage = new RoomPage(await context.newPage());
@@ -42,7 +44,7 @@ test('ルームページで、フィボナッチ数列デッキを選択して�
   await expect(roomPage3.minTag).toHaveText('最小?');
   await expect(roomPage3.avgTag).toHaveText('平均?');
   await expect(roomPage3.maxTag).toHaveText('最大?');
-})
+});
 
 test('ルームページで、フィボナッチ数列デッキを選択しており、カードをオープンしたとき、場に出されたカードの最大値、最小値、平均値が表示されること', async ({
   context,
@@ -84,7 +86,9 @@ test('ルームページで、フィボナッチ数列デッキを選択して�
   await expect(roomPage3.maxTag).toHaveText('最大13');
 });
 
-test('ルームページで、0-10デッキを選択しており、カードがオープンされてないとき、サマリーはすべて「？」であること', async ({ context }) => {
+test('ルームページで、0-10デッキを選択しており、カードがオープンされてないとき、サマリーはすべて「？」であること', async ({
+  context,
+}) => {
   // Given
   const roomId: string = createRoomId();
   const roomPage1: RoomPage = new RoomPage(await context.newPage());
@@ -125,7 +129,7 @@ test('ルームページで、0-10デッキを選択しており、カードが�
   await expect(roomPage3.minTag).toHaveText('最小?');
   await expect(roomPage3.avgTag).toHaveText('平均?');
   await expect(roomPage3.maxTag).toHaveText('最大?');
-})
+});
 
 test('ルームページで、0-10デッキを選択しており、カードをオープンしたとき、場に出されたカードの最大値、最小値、平均値が表示されること', async ({
   context,
@@ -168,7 +172,9 @@ test('ルームページで、0-10デッキを選択しており、カードを�
   await expect(roomPage3.maxTag).toHaveText('最大9');
 });
 
-test('ルームページで、Tシャツサイズデッキを選択しているとき、サマリーは表示されないこと', async ({ context }) => {
+test('ルームページで、Tシャツサイズデッキを選択しているとき、サマリーは表示されないこと', async ({
+  context,
+}) => {
   // Given
   const roomId: string = createRoomId();
   const roomPage1: RoomPage = new RoomPage(await context.newPage());
@@ -223,7 +229,7 @@ test('ルームページで、Tシャツサイズデッキを選択している�
   await expect(roomPage3.minTag).not.toBeVisible();
   await expect(roomPage3.avgTag).not.toBeVisible();
   await expect(roomPage3.maxTag).not.toBeVisible();
-})
+});
 
 test('ルームページで、カードを出していないプレイヤーがいる状態で、カードをオープンにしたとき、場に出されたカードの最大値、最小値、平均値が正しく表示されること', async ({
   context,

--- a/playwright/tests/rooms/summary.spec.ts
+++ b/playwright/tests/rooms/summary.spec.ts
@@ -2,7 +2,49 @@ import { test, expect } from '@playwright/test';
 import RoomPage from '../../models/room-page';
 import createRoomId from '../../helpers/createRoomId';
 
-test('ルームページで、カードをオープンしたとき、場に出されたカードの最大値、最小値、平均値が表示されること', async ({
+test('ルームページで、フィボナッチ数列デッキを選択しており、カードがオープンされてないとき、サマリーはすべて「？」であること', async ({ context }) => {
+  // Given
+  const roomId: string = createRoomId();
+  const roomPage1: RoomPage = new RoomPage(await context.newPage());
+  const roomPage2: RoomPage = new RoomPage(await context.newPage());
+  const roomPage3: RoomPage = new RoomPage(await context.newPage());
+  await roomPage1.goto(roomId);
+  await roomPage2.goto(roomId);
+  await roomPage3.goto(roomId);
+
+  await expect(roomPage1.deckSelect).toHaveValue('fibonacci');
+  await expect(roomPage2.deckSelect).toHaveValue('fibonacci');
+  await expect(roomPage3.deckSelect).toHaveValue('fibonacci');
+
+  // Then - カードを選択していなければ「？」
+  await expect(roomPage1.minTag).toHaveText('最小?');
+  await expect(roomPage1.avgTag).toHaveText('平均?');
+  await expect(roomPage1.maxTag).toHaveText('最大?');
+  await expect(roomPage2.minTag).toHaveText('最小?');
+  await expect(roomPage2.avgTag).toHaveText('平均?');
+  await expect(roomPage2.maxTag).toHaveText('最大?');
+  await expect(roomPage3.minTag).toHaveText('最小?');
+  await expect(roomPage3.avgTag).toHaveText('平均?');
+  await expect(roomPage3.maxTag).toHaveText('最大?');
+
+  // When - カードを選択
+  await roomPage1.selectCard('3');
+  await roomPage2.selectCard('5');
+  await roomPage3.selectCard('13');
+
+  // Then - カードを選択してもオープンしていなければ「？」
+  await expect(roomPage1.minTag).toHaveText('最小?');
+  await expect(roomPage1.avgTag).toHaveText('平均?');
+  await expect(roomPage1.maxTag).toHaveText('最大?');
+  await expect(roomPage2.minTag).toHaveText('最小?');
+  await expect(roomPage2.avgTag).toHaveText('平均?');
+  await expect(roomPage2.maxTag).toHaveText('最大?');
+  await expect(roomPage3.minTag).toHaveText('最小?');
+  await expect(roomPage3.avgTag).toHaveText('平均?');
+  await expect(roomPage3.maxTag).toHaveText('最大?');
+})
+
+test('ルームページで、フィボナッチ数列デッキを選択しており、カードをオープンしたとき、場に出されたカードの最大値、最小値、平均値が表示されること', async ({
   context,
 }) => {
   // Given
@@ -17,6 +59,131 @@ test('ルームページで、カードをオープンしたとき、場に出�
   await roomPage2.selectCard('5');
   await roomPage3.selectCard('13');
 
+  await expect(roomPage1.minTag).toHaveText('最小?');
+  await expect(roomPage1.avgTag).toHaveText('平均?');
+  await expect(roomPage1.maxTag).toHaveText('最大?');
+  await expect(roomPage2.minTag).toHaveText('最小?');
+  await expect(roomPage2.avgTag).toHaveText('平均?');
+  await expect(roomPage2.maxTag).toHaveText('最大?');
+  await expect(roomPage3.minTag).toHaveText('最小?');
+  await expect(roomPage3.avgTag).toHaveText('平均?');
+  await expect(roomPage3.maxTag).toHaveText('最大?');
+
+  // When
+  await roomPage1.openCards();
+
+  // Then
+  await expect(roomPage1.minTag).toHaveText('最小3');
+  await expect(roomPage1.avgTag).toHaveText('平均7');
+  await expect(roomPage1.maxTag).toHaveText('最大13');
+  await expect(roomPage2.minTag).toHaveText('最小3');
+  await expect(roomPage2.avgTag).toHaveText('平均7');
+  await expect(roomPage2.maxTag).toHaveText('最大13');
+  await expect(roomPage3.minTag).toHaveText('最小3');
+  await expect(roomPage3.avgTag).toHaveText('平均7');
+  await expect(roomPage3.maxTag).toHaveText('最大13');
+});
+
+test('ルームページで、0-10デッキを選択しており、カードがオープンされてないとき、サマリーはすべて「？」であること', async ({ context }) => {
+  // Given
+  const roomId: string = createRoomId();
+  const roomPage1: RoomPage = new RoomPage(await context.newPage());
+  const roomPage2: RoomPage = new RoomPage(await context.newPage());
+  const roomPage3: RoomPage = new RoomPage(await context.newPage());
+  await roomPage1.goto(roomId);
+  await roomPage2.goto(roomId);
+  await roomPage3.goto(roomId);
+  await roomPage1.selectDeck('sequential');
+
+  await expect(roomPage1.deckSelect).toHaveValue('sequential');
+  await expect(roomPage2.deckSelect).toHaveValue('sequential');
+  await expect(roomPage3.deckSelect).toHaveValue('sequential');
+
+  // Then - カードを選択していなければ「？」
+  await expect(roomPage1.minTag).toHaveText('最小?');
+  await expect(roomPage1.avgTag).toHaveText('平均?');
+  await expect(roomPage1.maxTag).toHaveText('最大?');
+  await expect(roomPage2.minTag).toHaveText('最小?');
+  await expect(roomPage2.avgTag).toHaveText('平均?');
+  await expect(roomPage2.maxTag).toHaveText('最大?');
+  await expect(roomPage3.minTag).toHaveText('最小?');
+  await expect(roomPage3.avgTag).toHaveText('平均?');
+  await expect(roomPage3.maxTag).toHaveText('最大?');
+
+  // When - カードを選択
+  await roomPage1.selectCard('0');
+  await roomPage2.selectCard('4');
+  await roomPage3.selectCard('6');
+
+  // Then - カードを選択してもオープンしていなければ「？」
+  await expect(roomPage1.minTag).toHaveText('最小?');
+  await expect(roomPage1.avgTag).toHaveText('平均?');
+  await expect(roomPage1.maxTag).toHaveText('最大?');
+  await expect(roomPage2.minTag).toHaveText('最小?');
+  await expect(roomPage2.avgTag).toHaveText('平均?');
+  await expect(roomPage2.maxTag).toHaveText('最大?');
+  await expect(roomPage3.minTag).toHaveText('最小?');
+  await expect(roomPage3.avgTag).toHaveText('平均?');
+  await expect(roomPage3.maxTag).toHaveText('最大?');
+})
+
+test('ルームページで、0-10デッキを選択しており、カードをオープンしたとき、場に出されたカードの最大値、最小値、平均値が表示されること', async ({
+  context,
+}) => {
+  // Given
+  const roomId: string = createRoomId();
+  const roomPage1: RoomPage = new RoomPage(await context.newPage());
+  const roomPage2: RoomPage = new RoomPage(await context.newPage());
+  const roomPage3: RoomPage = new RoomPage(await context.newPage());
+  await roomPage1.goto(roomId);
+  await roomPage2.goto(roomId);
+  await roomPage3.goto(roomId);
+  await roomPage1.selectDeck('sequential');
+  await roomPage1.selectCard('3');
+  await roomPage2.selectCard('5');
+  await roomPage3.selectCard('9');
+
+  await expect(roomPage1.minTag).toHaveText('最小?');
+  await expect(roomPage1.avgTag).toHaveText('平均?');
+  await expect(roomPage1.maxTag).toHaveText('最大?');
+  await expect(roomPage2.minTag).toHaveText('最小?');
+  await expect(roomPage2.avgTag).toHaveText('平均?');
+  await expect(roomPage2.maxTag).toHaveText('最大?');
+  await expect(roomPage3.minTag).toHaveText('最小?');
+  await expect(roomPage3.avgTag).toHaveText('平均?');
+  await expect(roomPage3.maxTag).toHaveText('最大?');
+
+  // When
+  await roomPage1.openCards();
+
+  // Then
+  await expect(roomPage1.minTag).toHaveText('最小3');
+  await expect(roomPage1.avgTag).toHaveText('平均5.7');
+  await expect(roomPage1.maxTag).toHaveText('最大9');
+  await expect(roomPage2.minTag).toHaveText('最小3');
+  await expect(roomPage2.avgTag).toHaveText('平均5.7');
+  await expect(roomPage2.maxTag).toHaveText('最大9');
+  await expect(roomPage3.minTag).toHaveText('最小3');
+  await expect(roomPage3.avgTag).toHaveText('平均5.7');
+  await expect(roomPage3.maxTag).toHaveText('最大9');
+});
+
+test('ルームページで、Tシャツサイズデッキを選択しているとき、サマリーは表示されないこと', async ({ context }) => {
+  // Given
+  const roomId: string = createRoomId();
+  const roomPage1: RoomPage = new RoomPage(await context.newPage());
+  const roomPage2: RoomPage = new RoomPage(await context.newPage());
+  const roomPage3: RoomPage = new RoomPage(await context.newPage());
+  await roomPage1.goto(roomId);
+  await roomPage2.goto(roomId);
+  await roomPage3.goto(roomId);
+  await roomPage1.selectDeck('tShirtSize');
+
+  await expect(roomPage1.deckSelect).toHaveValue('tShirtSize');
+  await expect(roomPage2.deckSelect).toHaveValue('tShirtSize');
+  await expect(roomPage3.deckSelect).toHaveValue('tShirtSize');
+
+  // Then - サマリータグは表示されない
   await expect(roomPage1.minTag).not.toBeVisible();
   await expect(roomPage1.avgTag).not.toBeVisible();
   await expect(roomPage1.maxTag).not.toBeVisible();
@@ -27,20 +194,36 @@ test('ルームページで、カードをオープンしたとき、場に出�
   await expect(roomPage3.avgTag).not.toBeVisible();
   await expect(roomPage3.maxTag).not.toBeVisible();
 
-  // When
+  // When - カードを選択
+  await roomPage1.selectCard('S');
+  await roomPage2.selectCard('M');
+  await roomPage3.selectCard('L');
+
+  // Then - カードを選択してもサマリータグは表示されない
+  await expect(roomPage1.minTag).not.toBeVisible();
+  await expect(roomPage1.avgTag).not.toBeVisible();
+  await expect(roomPage1.maxTag).not.toBeVisible();
+  await expect(roomPage2.minTag).not.toBeVisible();
+  await expect(roomPage2.avgTag).not.toBeVisible();
+  await expect(roomPage2.maxTag).not.toBeVisible();
+  await expect(roomPage3.minTag).not.toBeVisible();
+  await expect(roomPage3.avgTag).not.toBeVisible();
+  await expect(roomPage3.maxTag).not.toBeVisible();
+
+  // When - カードをオープン
   await roomPage1.openCards();
 
-  // Then
-  await expect(roomPage1.minTag).toHaveText('Min3');
-  await expect(roomPage1.avgTag).toHaveText('Avg7');
-  await expect(roomPage1.maxTag).toHaveText('Max13');
-  await expect(roomPage2.minTag).toHaveText('Min3');
-  await expect(roomPage2.avgTag).toHaveText('Avg7');
-  await expect(roomPage2.maxTag).toHaveText('Max13');
-  await expect(roomPage3.minTag).toHaveText('Min3');
-  await expect(roomPage3.avgTag).toHaveText('Avg7');
-  await expect(roomPage3.maxTag).toHaveText('Max13');
-});
+  // Then - カードをオープンしてもサマリータグは表示されない
+  await expect(roomPage1.minTag).not.toBeVisible();
+  await expect(roomPage1.avgTag).not.toBeVisible();
+  await expect(roomPage1.maxTag).not.toBeVisible();
+  await expect(roomPage2.minTag).not.toBeVisible();
+  await expect(roomPage2.avgTag).not.toBeVisible();
+  await expect(roomPage2.maxTag).not.toBeVisible();
+  await expect(roomPage3.minTag).not.toBeVisible();
+  await expect(roomPage3.avgTag).not.toBeVisible();
+  await expect(roomPage3.maxTag).not.toBeVisible();
+})
 
 test('ルームページで、カードを出していないプレイヤーがいる状態で、カードをオープンにしたとき、場に出されたカードの最大値、最小値、平均値が正しく表示されること', async ({
   context,
@@ -56,29 +239,29 @@ test('ルームページで、カードを出していないプレイヤーが�
   await roomPage1.selectCard('2');
   await roomPage2.selectCard('3');
 
-  await expect(roomPage1.minTag).not.toBeVisible();
-  await expect(roomPage1.avgTag).not.toBeVisible();
-  await expect(roomPage1.maxTag).not.toBeVisible();
-  await expect(roomPage2.minTag).not.toBeVisible();
-  await expect(roomPage2.avgTag).not.toBeVisible();
-  await expect(roomPage2.maxTag).not.toBeVisible();
-  await expect(roomPage3.minTag).not.toBeVisible();
-  await expect(roomPage3.avgTag).not.toBeVisible();
-  await expect(roomPage3.maxTag).not.toBeVisible();
+  await expect(roomPage1.minTag).toHaveText('最小?');
+  await expect(roomPage1.avgTag).toHaveText('平均?');
+  await expect(roomPage1.maxTag).toHaveText('最大?');
+  await expect(roomPage2.minTag).toHaveText('最小?');
+  await expect(roomPage2.avgTag).toHaveText('平均?');
+  await expect(roomPage2.maxTag).toHaveText('最大?');
+  await expect(roomPage3.minTag).toHaveText('最小?');
+  await expect(roomPage3.avgTag).toHaveText('平均?');
+  await expect(roomPage3.maxTag).toHaveText('最大?');
 
   // When
   await roomPage1.openCards();
 
   // Then
-  await expect(roomPage1.minTag).toHaveText('Min2');
-  await expect(roomPage1.avgTag).toHaveText('Avg2.5');
-  await expect(roomPage1.maxTag).toHaveText('Max3');
-  await expect(roomPage2.minTag).toHaveText('Min2');
-  await expect(roomPage2.avgTag).toHaveText('Avg2.5');
-  await expect(roomPage2.maxTag).toHaveText('Max3');
-  await expect(roomPage3.minTag).toHaveText('Min2');
-  await expect(roomPage3.avgTag).toHaveText('Avg2.5');
-  await expect(roomPage3.maxTag).toHaveText('Max3');
+  await expect(roomPage1.minTag).toHaveText('最小2');
+  await expect(roomPage1.avgTag).toHaveText('平均2.5');
+  await expect(roomPage1.maxTag).toHaveText('最大3');
+  await expect(roomPage2.minTag).toHaveText('最小2');
+  await expect(roomPage2.avgTag).toHaveText('平均2.5');
+  await expect(roomPage2.maxTag).toHaveText('最大3');
+  await expect(roomPage3.minTag).toHaveText('最小2');
+  await expect(roomPage3.avgTag).toHaveText('平均2.5');
+  await expect(roomPage3.maxTag).toHaveText('最大3');
 });
 
 test('ルームページで、「？」のカードがある状態で、カードをオープンしたとき、場に出されたカードの最大値、最小値、平均値が正しく表示されること', async ({
@@ -96,29 +279,29 @@ test('ルームページで、「？」のカードがある状態で、カー�
   await roomPage2.selectCard('?');
   await roomPage3.selectCard('2');
 
-  await expect(roomPage1.minTag).not.toBeVisible();
-  await expect(roomPage1.avgTag).not.toBeVisible();
-  await expect(roomPage1.maxTag).not.toBeVisible();
-  await expect(roomPage2.minTag).not.toBeVisible();
-  await expect(roomPage2.avgTag).not.toBeVisible();
-  await expect(roomPage2.maxTag).not.toBeVisible();
-  await expect(roomPage3.minTag).not.toBeVisible();
-  await expect(roomPage3.avgTag).not.toBeVisible();
-  await expect(roomPage3.maxTag).not.toBeVisible();
+  await expect(roomPage1.minTag).toHaveText('最小?');
+  await expect(roomPage1.avgTag).toHaveText('平均?');
+  await expect(roomPage1.maxTag).toHaveText('最大?');
+  await expect(roomPage2.minTag).toHaveText('最小?');
+  await expect(roomPage2.avgTag).toHaveText('平均?');
+  await expect(roomPage2.maxTag).toHaveText('最大?');
+  await expect(roomPage3.minTag).toHaveText('最小?');
+  await expect(roomPage3.avgTag).toHaveText('平均?');
+  await expect(roomPage3.maxTag).toHaveText('最大?');
 
   // When
   await roomPage1.openCards();
 
   // Then
-  await expect(roomPage1.minTag).toHaveText('Min1');
-  await expect(roomPage1.avgTag).toHaveText('Avg1.5');
-  await expect(roomPage1.maxTag).toHaveText('Max2');
-  await expect(roomPage2.minTag).toHaveText('Min1');
-  await expect(roomPage2.avgTag).toHaveText('Avg1.5');
-  await expect(roomPage2.maxTag).toHaveText('Max2');
-  await expect(roomPage3.minTag).toHaveText('Min1');
-  await expect(roomPage3.avgTag).toHaveText('Avg1.5');
-  await expect(roomPage3.maxTag).toHaveText('Max2');
+  await expect(roomPage1.minTag).toHaveText('最小1');
+  await expect(roomPage1.avgTag).toHaveText('平均1.5');
+  await expect(roomPage1.maxTag).toHaveText('最大2');
+  await expect(roomPage2.minTag).toHaveText('最小1');
+  await expect(roomPage2.avgTag).toHaveText('平均1.5');
+  await expect(roomPage2.maxTag).toHaveText('最大2');
+  await expect(roomPage3.minTag).toHaveText('最小1');
+  await expect(roomPage3.avgTag).toHaveText('平均1.5');
+  await expect(roomPage3.maxTag).toHaveText('最大2');
 });
 
 test('ルームページで、カードをオープンにしたあとで、プレイヤーがオーディエンスに変わっても、場に出されたカードの最大値、最小値、平均値が再計算され正しく表示されること', async ({
@@ -137,68 +320,27 @@ test('ルームページで、カードをオープンにしたあとで、プ�
   await roomPage3.selectCard('13');
   await roomPage1.openCards();
 
-  await expect(roomPage1.minTag).toHaveText('Min3');
-  await expect(roomPage1.avgTag).toHaveText('Avg7');
-  await expect(roomPage1.maxTag).toHaveText('Max13');
-  await expect(roomPage2.minTag).toHaveText('Min3');
-  await expect(roomPage2.avgTag).toHaveText('Avg7');
-  await expect(roomPage2.maxTag).toHaveText('Max13');
-  await expect(roomPage3.minTag).toHaveText('Min3');
-  await expect(roomPage3.avgTag).toHaveText('Avg7');
-  await expect(roomPage3.maxTag).toHaveText('Max13');
+  await expect(roomPage1.minTag).toHaveText('最小3');
+  await expect(roomPage1.avgTag).toHaveText('平均7');
+  await expect(roomPage1.maxTag).toHaveText('最大13');
+  await expect(roomPage2.minTag).toHaveText('最小3');
+  await expect(roomPage2.avgTag).toHaveText('平均7');
+  await expect(roomPage2.maxTag).toHaveText('最大13');
+  await expect(roomPage3.minTag).toHaveText('最小3');
+  await expect(roomPage3.avgTag).toHaveText('平均7');
+  await expect(roomPage3.maxTag).toHaveText('最大13');
 
   // When
   await roomPage3.selectMemberType('観客');
 
   // Then
-  await expect(roomPage1.minTag).toHaveText('Min3');
-  await expect(roomPage1.avgTag).toHaveText('Avg4');
-  await expect(roomPage1.maxTag).toHaveText('Max5');
-  await expect(roomPage2.minTag).toHaveText('Min3');
-  await expect(roomPage2.avgTag).toHaveText('Avg4');
-  await expect(roomPage2.maxTag).toHaveText('Max5');
-  await expect(roomPage3.minTag).toHaveText('Min3');
-  await expect(roomPage3.avgTag).toHaveText('Avg4');
-  await expect(roomPage3.maxTag).toHaveText('Max5');
-});
-
-test('ルームページで、場に数字のカードが出ていないとき、サマリーが表示されないこと', async ({
-  context,
-}) => {
-  // Given
-  const roomId: string = createRoomId();
-  const roomPage1: RoomPage = new RoomPage(await context.newPage());
-  const roomPage2: RoomPage = new RoomPage(await context.newPage());
-  const roomPage3: RoomPage = new RoomPage(await context.newPage());
-  await roomPage1.goto(roomId);
-  await roomPage2.goto(roomId);
-  await roomPage3.goto(roomId);
-  await roomPage1.selectDeck('Tシャツサイズ');
-  await roomPage1.selectCard('S');
-  await roomPage2.selectCard('M');
-  await roomPage3.selectCard('L');
-
-  await expect(roomPage1.minTag).not.toBeVisible();
-  await expect(roomPage1.avgTag).not.toBeVisible();
-  await expect(roomPage1.maxTag).not.toBeVisible();
-  await expect(roomPage2.minTag).not.toBeVisible();
-  await expect(roomPage2.avgTag).not.toBeVisible();
-  await expect(roomPage2.maxTag).not.toBeVisible();
-  await expect(roomPage3.minTag).not.toBeVisible();
-  await expect(roomPage3.avgTag).not.toBeVisible();
-  await expect(roomPage3.maxTag).not.toBeVisible();
-
-  // When
-  await roomPage1.openCards();
-
-  // Then
-  await expect(roomPage1.minTag).not.toBeVisible();
-  await expect(roomPage1.avgTag).not.toBeVisible();
-  await expect(roomPage1.maxTag).not.toBeVisible();
-  await expect(roomPage2.minTag).not.toBeVisible();
-  await expect(roomPage2.avgTag).not.toBeVisible();
-  await expect(roomPage2.maxTag).not.toBeVisible();
-  await expect(roomPage3.minTag).not.toBeVisible();
-  await expect(roomPage3.avgTag).not.toBeVisible();
-  await expect(roomPage3.maxTag).not.toBeVisible();
+  await expect(roomPage1.minTag).toHaveText('最小3');
+  await expect(roomPage1.avgTag).toHaveText('平均4');
+  await expect(roomPage1.maxTag).toHaveText('最大5');
+  await expect(roomPage2.minTag).toHaveText('最小3');
+  await expect(roomPage2.avgTag).toHaveText('平均4');
+  await expect(roomPage2.maxTag).toHaveText('最大5');
+  await expect(roomPage3.minTag).toHaveText('最小3');
+  await expect(roomPage3.avgTag).toHaveText('平均4');
+  await expect(roomPage3.maxTag).toHaveText('最大5');
 });


### PR DESCRIPTION
カードオープンごとに要素の表示非表示があり、画面表示が動くのが嫌なので固定のために常に集計タグを表示しておく。