### PR TITLE
Add Dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/set-auto-merge-for-dependabot.yml
+++ b/.github/workflows/set-auto-merge-for-dependabot.yml
@@ -1,0 +1,17 @@
+name: Dependabot auto-merge
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  set-auto-merge-for-dependabot:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'at946/tenkiru'
+    steps:
+      - name: Enable auto-merge for Dependabot PRs
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
## Summary:

This PR introduces a new GitHub Actions workflow that automatically enables auto-merge (with squash) for pull requests created by Dependabot.

## Details:

Adds a workflow file: .github/workflows/set-auto-merge-for-dependabot.yml
The workflow is triggered on all pull requests.
It specifically targets PRs opened by dependabot[bot] in the at946/tenkiru repository.
Grants necessary permissions to write to contents and pull requests.
Uses the GitHub CLI (gh pr merge --auto --squash) to enable auto-merge for eligible Dependabot PRs.

## Purpose:

Automating the merging of Dependabot PRs saves maintainers time and ensures that dependency updates are promptly incorporated once checks pass.