### PR TITLE
fix: Resolve fly deploy health check and corepack EACCES issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,11 +28,15 @@ WORKDIR /app
 
 ENV NODE_ENV production
 ENV NEXT_TELEMETRY_DISABLED 1
+ENV COREPACK_HOME="/app/.corepack"
 
 RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 nextjs
 
 COPY --from=builder /app ./
+
+# Create the COREPACK_HOME directory and set ownership
+RUN mkdir -p ${COREPACK_HOME} && chown -R nextjs:nodejs ${COREPACK_HOME}
 
 USER nextjs
 

--- a/fly.toml
+++ b/fly.toml
@@ -12,7 +12,7 @@ processes = []
     NEXT_PUBLIC_GOOGLE_ADSENSE_ID = "ca-pub-8890406023301925"
 
 [env]
-  PORT = "8080"
+  PORT = "3000"
 
 [experimental]
   allowed_public_ports = []
@@ -20,7 +20,7 @@ processes = []
 
 [[services]]
   http_checks = []
-  internal_port = 8080
+  internal_port = 3000
   processes = ["app"]
   protocol = "tcp"
   script_checks = []
@@ -38,7 +38,7 @@ processes = []
     port = 443
 
   [[services.tcp_checks]]
-    grace_period = "1s"
+    grace_period = "20s"
     interval = "15s"
     restart_limit = 0
-    timeout = "2s"
+    timeout = "5s"


### PR DESCRIPTION
This PR addresses several issues encountered during fly deploy:

- **fly.toml updates:**
  - Changed  and  to  to align with Next.js's default listening port.
  - Increased  to  and  to  for TCP health checks, providing more time for the application to start up.
- **Dockerfile updates:**
  - Added TERM_PROGRAM=iTerm.app
PYENV_ROOT=/Users/asato/.pyenv
SHELL=/bin/zsh
TERM=xterm-256color
TMPDIR=/var/folders/28/rcnm9pbs39qgv0kln4r1m1f80000gn/T/
TERM_PROGRAM_VERSION=3.6.9
TERM_SESSION_ID=w0t0p1:00A33523-24C5-469F-AC2B-99C14022831A
PNPM_HOME=/Users/asato/Library/pnpm
USER=asato
COMMAND_MODE=unix2003
SSH_AUTH_SOCK=/private/tmp/com.apple.launchd.JLu9NDKR8g/Listeners
__CF_USER_TEXT_ENCODING=0x1F5:0x1:0xE
TERM_FEATURES=T3LrMSc7UUw9Ts3BFGsSyHNoSxFP
LSCOLORS=cxfxcxdxbxegexabagacad
PATH=/Users/asato/.pyenv/shims:/Users/asato/.pyenv/bin:/Users/asato/Library/pnpm:/Users/asato/.nodebrew/current/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/Library/Apple/usr/bin:/Applications/iTerm 2.app/Contents/Resources/utilities:/Users/asato/development/flutter/bin:/Users/asato/Library/Android/sdk/tools/bin
TERMINFO_DIRS=/Applications/iTerm 2.app/Contents/Resources/terminfo:/usr/share/terminfo
LaunchInstanceID=EA14578F-21E5-43F1-9A02-3D741FDD8368
__CFBundleIdentifier=com.googlecode.iterm2
PWD=/Users/asato/Documents/GitHub/tenkiru
LANG=ja_JP.UTF-8
ITERM_PROFILE=Default
NODE_PATH=/Users/asato/Library/pnpm/global/5/.pnpm/@google+gemini-cli@0.1.4/node_modules/@google/gemini-cli/dist/node_modules:/Users/asato/Library/pnpm/global/5/.pnpm/@google+gemini-cli@0.1.4/node_modules/@google/gemini-cli/node_modules:/Users/asato/Library/pnpm/global/5/.pnpm/@google+gemini-cli@0.1.4/node_modules/@google/node_modules:/Users/asato/Library/pnpm/global/5/.pnpm/@google+gemini-cli@0.1.4/node_modules:/Users/asato/Library/pnpm/global/5/.pnpm/node_modules
XPC_FLAGS=0x0
XPC_SERVICE_NAME=0
COLORFGBG=15;0
HOME=/Users/asato
SHLVL=2
PYENV_SHELL=zsh
LC_TERMINAL_VERSION=3.6.9
ITERM_SESSION_ID=w0t0p1:00A33523-24C5-469F-AC2B-99C14022831A
LOGNAME=asato
LC_TERMINAL=iTerm2
SQLITE_EXEMPT_PATH_FROM_VNODE_GUARDS=/Users/asato/Library/WebKit/Databases
SECURITYSESSIONID=186a1
COLORTERM=truecolor
_=/usr/bin/ENV
COREPACK_HOME=/app/.corepack to specify a writable cache directory for Corepack.
  - Added  to ensure the  user has proper write permissions to the Corepack cache directory.

These changes aim to resolve the 'Health check failed' and 'EACCES: permission denied' errors during deployment.