### PR TITLE
Grant workflows contents read permission

### DIFF
--- a/.github/workflows/mainMerge.yml
+++ b/.github/workflows/mainMerge.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - main
+
+permissions:
+  contents: read
+
 env:
   FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 jobs:

--- a/.github/workflows/pullRequest.yml
+++ b/.github/workflows/pullRequest.yml
@@ -2,6 +2,9 @@ name: lint and e2e tests for pull requests
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   job:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Add an explicit permissions block (contents: read) to .github/workflows/mainMerge.yml and .github/workflows/pullRequest.yml. This restricts the workflows to read-only access to repository contents for the main push and pull_request runs, aligning with least-privilege practices and recent GitHub Actions permission defaults.