### PR TITLE
Tune Sentry config and middleware matcher

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -41,10 +41,11 @@ module.exports = withSentryConfig(module.exports, {
 
   webpack: {
     // Enables automatic instrumentation of Vercel Cron Monitors. (Does not yet work with App Router route handlers.)
-    // See the following for more information:
+    // Set to false to prevent additional Performance Unit consumption from cron monitors.
+    automaticVercelMonitors: false,
+
     // https://docs.sentry.io/product/crons/
     // https://vercel.com/docs/cron-jobs
-    automaticVercelMonitors: true,
 
     // Tree-shaking options for reducing bundle size
     treeshake: {

--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -13,7 +13,7 @@ Sentry.init({
   integrations: [Sentry.replayIntegration()],
 
   // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-  tracesSampleRate: 1,
+  tracesSampleRate: 0.05,
   // Enable logs to be sent to Sentry
   enableLogs: true,
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -4,5 +4,17 @@ import { routing } from '@/i18n/routing';
 export default createMiddleware(routing);
 
 export const config = {
-  matcher: ['/((?!sentry-tunnel|api|_next/static|_next/image|favicon.ico|audio/|ads.txt|opengraph-image.jpg).*)'],
+  matcher: [
+    /*
+     * 次のパス以外にマッチさせる（MiddlewareとSentry計測の対象外にする）:
+     * - api (API routes)
+     * - _next/static (static files)
+     * - _next/image (image optimization files)
+     * - _next/data (Next.js data prefetching)
+     * - _vercel (Vercel internal requests)
+     * - sentry-tunnel (Sentry tunnel route)
+     * - 静的ファイルと画像アセット (favicon, robots.txt, sitemap.xml, manifest.json, 各種画像拡張子)
+     */
+    '/((?!api|_next/static|_next/data|_next/image|_vercel|sentry-tunnel|favicon.ico|robots.txt|sitemap.xml|manifest.json|ads.txt|audio/|.*\\.(?:svg|png|jpg|jpeg|gif|webp|ico|opengraph-image.jpg)$).*)',
+  ],
 };


### PR DESCRIPTION
Disable automatic Vercel cron monitors in next.config.js to avoid extra Performance Unit consumption; reduce client tracing from 100% to 5% (tracesSampleRate 1 -> 0.05) in src/instrumentation-client.ts to lower telemetry volume; and expand the middleware matcher in src/proxy.ts to exclude more internal/static routes and common asset extensions (adds _next/data, _vercel, robots.txt, sitemap.xml, manifest.json, various image extensions, etc.) with an explanatory comment. These changes reduce instrumentation overhead and prevent Sentry from capturing unnecessary static or internal requests.