### PR TITLE
Disable sitemap index; enable npm pre/post scripts

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+enable-pre-post-scripts=true

--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -3,6 +3,7 @@
 const config = {
   siteUrl: process.env.NEXT_PUBLIC_BASE_URL,
   generateRobotsTxt: true,
+  generateIndexSitemap: false,
   exclude: ['/rooms/*'],
 };
 


### PR DESCRIPTION
Add .npmrc to enable pre/post scripts for npm. Update next-sitemap.config.js to set generateIndexSitemap to false (while keeping robots.txt generation and excluding /rooms/*), preventing an index sitemap from being emitted.