### PR TITLE
Add default locale and sitemap alternates

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -31,6 +31,7 @@ export async function generateMetadata(props: MetaProps) {
       languages: {
         en: '/en',
         ja: '/ja',
+        'x-default': '/',
       },
     },
     openGraph: {

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -14,6 +14,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
         lastModified: new Date(),
         changeFrequency: 'monthly',
         priority: page === '' ? 1.0 : 0.8,
+        alternates: {
+          languages: {
+            en: `${baseUrl}/en${page}`,
+            ja: `${baseUrl}/ja${page}`,
+          },
+        },
       });
     }
   }


### PR DESCRIPTION
Add an 'x-default' mapping to the locale metadata to point unspecified visitors to the root, and include language alternates for en/ja in the generated sitemap entries (using baseUrl + page). These changes improve hreflang support and SEO for localized pages.